### PR TITLE
Fix Theia electron build warnings and start command

### DIFF
--- a/theia-app/package.json
+++ b/theia-app/package.json
@@ -5,9 +5,9 @@
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "yarn run build",
-    "build": "theia build --app-target=electron",
-    "start": "theia start --app-target=electron --plugins=local-dir:../plugins",
-    "start:web": "theia start",
+    "build": "theia build",
+    "start": "theia start --plugins=local-dir:../plugins",
+    "start:web": "theia start --app-target=browser --plugins=local-dir:../plugins",
     "start:electron": "theia start --app-target=electron --plugins=local-dir:../plugins"
   },
   "dependencies": {
@@ -24,5 +24,10 @@
   },
   "devDependencies": {
     "@theia/cli": "1.65.0"
-  }
+  },
+  "main": "lib/backend/electron-main.js",
+  "theia": {
+    "target": "electron"
+  },
+  "packageManager": "yarn@1.22.22"
 }

--- a/theia-app/package.json
+++ b/theia-app/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "prepare": "yarn run build",
     "build": "theia build --app-target=electron",
-    "start": "theia start",
+    "start": "theia start --app-target=electron --plugins=local-dir:../plugins",
+    "start:web": "theia start",
     "start:electron": "theia start --app-target=electron --plugins=local-dir:../plugins"
   },
   "dependencies": {
@@ -18,10 +19,10 @@
     "@theia/navigator": "1.65.0",
     "@theia/preferences": "1.65.0",
     "@theia/terminal": "1.65.0",
-    "@theia/workspace": "1.65.0"
+    "@theia/workspace": "1.65.0",
+    "electron": "37.2.1"
   },
   "devDependencies": {
-    "@theia/cli": "1.65.0",
-    "electron": "37.2.1"
+    "@theia/cli": "1.65.0"
   }
 }

--- a/theia-app/package.json
+++ b/theia-app/package.json
@@ -5,22 +5,23 @@
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "yarn run build",
-    "build": "theia build",
+    "build": "theia build --app-target=electron",
     "start": "theia start",
-    "start:electron": "theia start --plugins=local-dir:../plugins"
+    "start:electron": "theia start --app-target=electron --plugins=local-dir:../plugins"
   },
   "dependencies": {
     "@theia/core": "1.65.0",
     "@theia/editor": "1.65.0",
+    "@theia/electron": "1.65.0",
     "@theia/filesystem": "1.65.0",
     "@theia/monaco": "1.65.0",
     "@theia/navigator": "1.65.0",
     "@theia/preferences": "1.65.0",
     "@theia/terminal": "1.65.0",
-    "@theia/workspace": "1.65.0",
-    "@theia/electron": "1.65.0"
+    "@theia/workspace": "1.65.0"
   },
   "devDependencies": {
-    "@theia/cli": "1.65.0"
+    "@theia/cli": "1.65.0",
+    "electron": "37.2.1"
   }
 }


### PR DESCRIPTION
## Summary
- add the Electron runtime dependency required by @theia/electron
- ensure the build and start scripts target the electron distribution

## Testing
- ⚠️ `yarn install` (fails: native-keymap could not be built in the container)


------
https://chatgpt.com/codex/tasks/task_e_68e3da160de4832892e85a209ca4610b